### PR TITLE
Remove casting for array field

### DIFF
--- a/changes/fix-array-field-bug.bugfix
+++ b/changes/fix-array-field-bug.bugfix
@@ -1,0 +1,1 @@
+Array custom fields get annotated correctly.

--- a/django_features/custom_fields/models/base.py
+++ b/django_features/custom_fields/models/base.py
@@ -56,7 +56,7 @@ class CustomFieldModelBaseManager(models.Manager):
                     formated=Cast(
                         (
                             RawSQL(
-                                f"ARRAY(SELECT (jsonb_array_elements_text(value))::{field.sql_field})",
+                                "ARRAY(SELECT (jsonb_array_elements_text(value)))",
                                 [],
                             )
                             if field.multiple


### PR DESCRIPTION
## Description

Array custom fields were annotated falsy. Instead of the whole string there was only the first letter per array item. This is fixed by removing the type casting. It still works for different field types.


## Checklist

The following checklist should help us to stick to our "definition of done":

- [ ] Proposed changes include tests.
- [ ] Good error handling with useful messages
- [x] Changelog added
- [ ] Django migration files have a meaningful name (not 0000_auto_xyz.py nor 0000_alter_xy_model).
- [ ] Strings are set and translation catalogs have been updated (i18n-scan or i18n-update) and translations made.
- [ ] Readme has been updated if changes interfere with the setup process.
