### PR TITLE
Fix AttributeError when overriding serializer

### DIFF
--- a/changes/TI-2994.bugfix
+++ b/changes/TI-2994.bugfix
@@ -1,0 +1,1 @@
+Fixes AttributeError when overriding the init function of the CustomFieldBaseModelSerializer because of the params. (`TI-2994 <https://4teamwork.atlassian.net/browse/TI-2994>`_)

--- a/django_features/custom_fields/serializers.py
+++ b/django_features/custom_fields/serializers.py
@@ -63,6 +63,7 @@ CustomFieldData = namedtuple(
 
 
 class CustomFieldBaseModelSerializer(serializers.ModelSerializer):
+    _exclude_custom_fields = False
     _custom_fields: list[CustomFieldData] = []
     _unique_choice_field = "id"
     _write_only_serializer = False
@@ -76,13 +77,13 @@ class CustomFieldBaseModelSerializer(serializers.ModelSerializer):
         self,
         instance: Any = None,
         data: Any = empty,
-        exclude_custom_fields: bool = False,
-        write_only_serializer: bool = False,
         **kwargs: Any,
     ) -> None:
-        self.exclude_custom_fields: bool = exclude_custom_fields
-        self.write_only_serializer = (
-            write_only_serializer or self._write_only_serializer
+        self.exclude_custom_fields: bool = kwargs.get(
+            "exclude_custom_fields", self._exclude_custom_fields
+        )
+        self.write_only_serializer = kwargs.get(
+            "write_only_serializer", self._write_only_serializer
         )
         super().__init__(instance, data, **kwargs)
 


### PR DESCRIPTION
## Description

Fixes `AttributeError` when overriding the `__init__` function of the `CustomFieldBaseModelSerializer` because of the params.

Belongs to PBI [TI-2994].

## Checklist

The following checklist should help us to stick to our "definition of done":

- [ ] Proposed changes include tests.
- [ ] Good error handling with useful messages
- [x] Changelog added
- [ ] Django migration files have a meaningful name (not 0000_auto_xyz.py nor 0000_alter_xy_model).
- [ ] Strings are set and translation catalogs have been updated (i18n-scan or i18n-update) and translations made.
- [ ] Readme has been updated if changes interfere with the setup process.
