### PR TITLE
Make swappable dependency dynamic

### DIFF
--- a/changes/TI-3652.bugfix
+++ b/changes/TI-3652.bugfix
@@ -1,0 +1,1 @@
+Make initial custom fields dependencies dynamic to fix dependency inconsistency. (`TI-3652 <https://4teamwork.atlassian.net/browse/TI-3652>`_)


### PR DESCRIPTION
## Description

This migration has a dynamic dependency on the swappable model. The problem is that the migration has already been applied because the swappable feature was implemented later. To avoid dependency issues during migrating, the dependencies for this migration are dynamic. If the migration has already been applied, the dependencies are only 0002_remove_content_type_name. If the migration has not been applied yet, the dependencies are 0002_remove_content_type_name and the swappable dependency.


Belongs to PBI [TI-3652].

## Checklist

The following checklist should help us to stick to our "definition of done":

- [ ] Proposed changes include tests.
- [ ] Good error handling with useful messages
- [x] Changelog added
- [ ] Django migration files have a meaningful name (not 0000_auto_xyz.py nor 0000_alter_xy_model).
- [ ] Strings are set and translation catalogs have been updated (i18n-scan or i18n-update) and translations made.
- [ ] Readme has been updated if changes interfere with the setup process.


[TI-3652]: https://4teamwork.atlassian.net/browse/TI-3652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ