### PR TITLE
Fix list serializer  

### DIFF
--- a/app/serializers/__init__.py
+++ b/app/serializers/__init__.py
@@ -6,6 +6,6 @@ from django_features.serializers import MappingSerializer
 
 
 class BaseMappingSerializer(MappingSerializer):
-    @property
+    @property  # type: ignore[misc]
     def mapping(self) -> dict[str, dict[str, Any]]:
         return config.MODEL_MAPPING_FIELD

--- a/app/serializers/person.py
+++ b/app/serializers/person.py
@@ -30,6 +30,6 @@ class PersonMappingSerializer(BaseMappingSerializer):
         model = Person
         fields = "__all__"
 
-    @property
+    @property  # type: ignore[misc]
     def mapping(self) -> dict[str, dict[str, Any]]:
         return config.MODEL_MAPPING_FIELD

--- a/app/tests/test_mapping_serializer.py
+++ b/app/tests/test_mapping_serializer.py
@@ -4,6 +4,8 @@ from datetime import timezone
 
 from constance.test import override_config
 from django.contrib.contenttypes.models import ContentType
+from rest_framework.exceptions import ErrorDetail
+from rest_framework.exceptions import ValidationError
 
 from app.custom_field.models import CustomField
 from app.custom_field.models import CustomValue
@@ -299,3 +301,36 @@ class MappingSerializerTestCase(APITestCase):
         self.assertEqual(1, stefanie.addresses.count())
         self.assertEqual(hugo, hugo.addresses.first().target)
         self.assertEqual(stefanie, stefanie.addresses.last().target)
+
+    @override_config(MODEL_MAPPING_FIELD=MODEL_MAPPING_FIELD)
+    def test_list_mapping_serializer_validation_error(self) -> None:
+        data = [
+            {"external_lastname": "Boss"},
+            {"external_lastname": "Muster"},
+        ]
+
+        serializer = PersonMappingSerializer(data=data, many=True)
+        with self.assertRaises(ValidationError) as exception:
+            serializer.is_valid(raise_exception=True)
+
+        self.assertEqual(
+            exception.exception.detail,
+            [
+                {
+                    "firstname": [
+                        ErrorDetail(
+                            string="Dieses Feld ist zwingend erforderlich.",
+                            code="required",
+                        )
+                    ]
+                },
+                {
+                    "firstname": [
+                        ErrorDetail(
+                            string="Dieses Feld ist zwingend erforderlich.",
+                            code="required",
+                        )
+                    ]
+                },
+            ],
+        )

--- a/app/tests/test_mapping_serializer_data.py
+++ b/app/tests/test_mapping_serializer_data.py
@@ -10,7 +10,7 @@ class TestMappingSerializer(MappingSerializer):
         model = models.Person
         fields = "__all__"
 
-    @property
+    @property  # type: ignore[misc]
     def mapping(self) -> dict[str, dict[str, Any]]:
         return {
             "person": {

--- a/changes/TI-3779-1.bugfix
+++ b/changes/TI-3779-1.bugfix
@@ -1,0 +1,1 @@
+The `PropertySerializerMixin` and the `DataMappingSerializerMixin` do not inherit from rest_framework.serializers.Serializer. (`TI-3779 <https://4teamwork.atlassian.net/browse/TI-3779>`_)

--- a/changes/TI-3779.bugfix
+++ b/changes/TI-3779.bugfix
@@ -1,0 +1,1 @@
+Renames the `PropertySerializer` to `PropertySerializerMixin` and `DataMappingSerializer` to `DataMappingSerializerMixin`. (`TI-3779 <https://4teamwork.atlassian.net/browse/TI-3779>`_)

--- a/django_features/serializers.py
+++ b/django_features/serializers.py
@@ -13,7 +13,7 @@ from django_features.custom_fields.serializers import CustomFieldBaseModelSerial
 from django_features.fields import UUIDRelatedField
 
 
-class PropertySerializer(serializers.Serializer):
+class PropertySerializerMixin:
     relation_separator: str = "."
 
     class Meta:
@@ -72,7 +72,7 @@ class PropertySerializer(serializers.Serializer):
         self._model = value
 
 
-class BaseMappingSerializer(CustomFieldBaseModelSerializer, PropertySerializer):
+class BaseMappingSerializer(CustomFieldBaseModelSerializer, PropertySerializerMixin):
     serializer_related_field = UUIDRelatedField
     serializer_related_fields: dict[str, Any] = {}
 
@@ -210,7 +210,7 @@ class NestedMappingSerializer(BaseMappingSerializer):
         super().__init__(*args, **kwargs)
 
 
-class DataMappingSerializer(PropertySerializer):
+class DataMappingSerializerMixin(PropertySerializerMixin):
     _default_prefix = "default"
     _format_prefix = "format"
 
@@ -254,7 +254,7 @@ class DataMappingSerializer(PropertySerializer):
                 value = format_func(value)
             internal_field_path = internal_name.split(self.relation_separator)
             if value is None:
-                if self.instance is None:
+                if getattr(self, "instance") is None:
                     continue
                 else:
                     try:
@@ -269,7 +269,7 @@ class DataMappingSerializer(PropertySerializer):
         return data
 
 
-class ListDataMappingSerializer(serializers.ListSerializer, DataMappingSerializer):
+class ListDataMappingSerializer(serializers.ListSerializer, DataMappingSerializerMixin):
     def __init__(self, data: Any = empty, *args: Any, **kwargs: Any) -> None:
         self.instance = None
         self.mapping = kwargs.pop("mapping", {})
@@ -285,7 +285,7 @@ class ListDataMappingSerializer(serializers.ListSerializer, DataMappingSerialize
         return list_data
 
 
-class MappingSerializer(BaseMappingSerializer, DataMappingSerializer):
+class MappingSerializer(BaseMappingSerializer, DataMappingSerializerMixin):
     list_serializer_class = ListDataMappingSerializer
 
     class Meta:


### PR DESCRIPTION
## Description

- Change property serializer and data mapping serializer to mixins
- Add type ignores for properties and write test with validation error


Belongs to PBI [TI-3779].

## Checklist

The following checklist should help us to stick to our "definition of done":

- [x] Proposed changes include tests.
- [ ] Good error handling with useful messages
- [x] Changelog added
- [ ] Django migration files have a meaningful name (not 0000_auto_xyz.py nor 0000_alter_xy_model).
- [ ] Strings are set and translation catalogs have been updated (i18n-scan or i18n-update) and translations made.
- [ ] Readme has been updated if changes interfere with the setup process.


[TI-3779]: https://4teamwork.atlassian.net/browse/TI-3779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ