### PR TITLE
Distinguish omitted mapping inputs from explicit ``None`` values.

### DIFF
--- a/app/tests/test_mapping_serializer_data.py
+++ b/app/tests/test_mapping_serializer_data.py
@@ -232,6 +232,20 @@ class MappingSerializerTestCase(APITestCase):
             ],
         )
 
+    def test_many_hooks_receive_current_unmapped_item(self) -> None:
+        data = [
+            {"title": "Dr.", "external_nullable": "Boss"},
+            {"title": "Prof.", "fallback_lastname": "Muster"},
+        ]
+
+        serializer = ContextAwareMappingSerializer(data=data, many=True)
+
+        self.assertEqual(
+            serializer.initial_data,
+            [{"lastname": "Dr. Boss"}, {"lastname": "Prof. Muster"}],
+        )
+        self.assertEqual(serializer.child.unmapped_data, data)
+
     def test_many_calls_default_once_per_missing_item(self) -> None:
         serializer = DefaultFieldMappingSerializer(
             data=[{}, {"external_nullable": None}, {}], many=True

--- a/app/tests/test_mapping_serializer_data.py
+++ b/app/tests/test_mapping_serializer_data.py
@@ -2,7 +2,11 @@ from typing import Any
 
 from app import models
 from app.tests import APITestCase
+from app.tests.factories import PersonFactory
+from django_features.serializers import ListDataMappingSerializer
 from django_features.serializers import MappingSerializer
+from django_features.system_message.factories import SystemMessageFactory
+from django_features.system_message.models import SystemMessage
 
 
 class TestMappingSerializer(MappingSerializer):
@@ -69,6 +73,58 @@ class FormattingFieldMappingSerializer(NullableFieldMappingSerializer):
         self.formatted_values = getattr(self, "formatted_values", [])
         self.formatted_values.append(value)
         return value
+
+
+class DefaultAndFormattingFieldMappingSerializer(NullableFieldMappingSerializer):
+    def default_lastname(self) -> str:
+        return "Default lastname"
+
+    def format_lastname(self, value: Any) -> str:
+        return f"Formatted {value}"
+
+
+class ContextAwareMappingSerializer(NullableFieldMappingSerializer):
+    def default_lastname(self) -> str:
+        return self.unmapped_data["fallback_lastname"]
+
+    def format_lastname(self, value: Any) -> str:
+        return f"{self.unmapped_data['title']} {value}"
+
+
+class OverridingListSerializer(ListDataMappingSerializer):
+    def map_list_data(self, initial_data: Any) -> Any:
+        return [{"lastname": "Overridden lastname"} for _ in initial_data]
+
+
+class CustomListMappingSerializer(NullableFieldMappingSerializer):
+    class Meta(NullableFieldMappingSerializer.Meta):
+        list_serializer_class = OverridingListSerializer
+
+
+class DefaultedModelFieldMappingSerializer(MappingSerializer):
+    class Meta:
+        model = SystemMessage
+        fields = "__all__"
+
+    @property  # type: ignore[misc]
+    def mapping(self) -> dict[str, dict[str, Any]]:
+        return {"systemmessage": {"external_order": "order"}}
+
+
+class MultipleNestedRelationsMappingSerializer(MappingSerializer):
+    class Meta:
+        model = models.Person
+        fields = "__all__"
+
+    @property  # type: ignore[misc]
+    def mapping(self) -> dict[str, dict[str, Any]]:
+        return {
+            "person": {
+                "external_firstname": "firstname",
+                "external_municipality": "place_of_residence.title",
+                "external_person_type": "person_type.title",
+            }
+        }
 
 
 class MappingSerializerTestCase(APITestCase):
@@ -156,6 +212,72 @@ class MappingSerializerTestCase(APITestCase):
         self.assertEqual(serializer.initial_data, {})
         self.assertFalse(hasattr(serializer, "formatted_values"))
 
+    def test_default_is_formatted(self) -> None:
+        serializer = DefaultAndFormattingFieldMappingSerializer(data={})
+
+        self.assertEqual(
+            serializer.initial_data, {"lastname": "Formatted Default lastname"}
+        )
+
+    def test_many_uses_child_defaults_and_formatters(self) -> None:
+        serializer = DefaultAndFormattingFieldMappingSerializer(
+            data=[{}, {"external_nullable": None}], many=True
+        )
+
+        self.assertEqual(
+            serializer.initial_data,
+            [
+                {"lastname": "Formatted Default lastname"},
+                {"lastname": "Formatted None"},
+            ],
+        )
+
+    def test_many_calls_default_once_per_missing_item(self) -> None:
+        serializer = DefaultFieldMappingSerializer(
+            data=[{}, {"external_nullable": None}, {}], many=True
+        )
+
+        self.assertEqual(
+            serializer.initial_data,
+            [
+                {"lastname": "Default lastname"},
+                {"lastname": None},
+                {"lastname": "Default lastname"},
+            ],
+        )
+        self.assertEqual(serializer.child.default_calls, 2)
+
+    def test_many_calls_formatter_for_present_items_only(self) -> None:
+        serializer = FormattingFieldMappingSerializer(
+            data=[{}, {"external_nullable": None}, {"external_nullable": "Boss"}],
+            many=True,
+        )
+
+        self.assertEqual(
+            serializer.initial_data,
+            [{}, {"lastname": None}, {"lastname": "Boss"}],
+        )
+        self.assertEqual(serializer.child.formatted_values, [None, "Boss"])
+
+    def test_many_uses_overridden_list_mapping(self) -> None:
+        serializer = CustomListMappingSerializer(
+            data=[{"external_nullable": "Original lastname"}], many=True
+        )
+
+        self.assertEqual(serializer.initial_data, [{"lastname": "Overridden lastname"}])
+
+    def test_invalid_non_mapping_input_is_left_for_drf_validation(self) -> None:
+        serializer = NullableFieldMappingSerializer(data=[])
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors["non_field_errors"][0].code, "invalid")
+
+    def test_invalid_non_list_many_input_is_left_for_drf_validation(self) -> None:
+        serializer = NullableFieldMappingSerializer(data={}, many=True)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors["non_field_errors"][0].code, "not_a_list")
+
     def test_nested_mapping_distinguishes_missing_and_explicit_none(self) -> None:
         serializer = NestedFieldMappingSerializer()
 
@@ -178,6 +300,161 @@ class MappingSerializerTestCase(APITestCase):
                 ]
             ),
             [{}, {}, {"lastname": None}],
+        )
+
+    def test_update_clears_explicit_nullable_field(self) -> None:
+        person = PersonFactory(lastname="Boss")
+        serializer = NullableFieldMappingSerializer(
+            person, data={"external_nullable": None}
+        )
+
+        self.assertTrue(serializer.is_valid(raise_exception=True))
+        serializer.save()
+
+        person.refresh_from_db()
+        self.assertIsNone(person.lastname)
+
+    def test_update_rejects_explicit_none_for_non_nullable_field(self) -> None:
+        person = PersonFactory(firstname="Hugo")
+        serializer = NonNullableFieldMappingSerializer(
+            person, data={"external_non_nullable": None}
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors["firstname"][0].code, "null")
+
+        person.refresh_from_db()
+        self.assertEqual(person.firstname, "Hugo")
+
+    def test_full_and_partial_updates_preserve_omitted_fields(self) -> None:
+        for partial in (False, True):
+            with self.subTest(partial=partial):
+                person = PersonFactory(lastname="Boss")
+                serializer = NullableFieldMappingSerializer(
+                    person, data={}, partial=partial
+                )
+
+                self.assertTrue(serializer.is_valid(raise_exception=True))
+                serializer.save()
+
+                person.refresh_from_db()
+                self.assertEqual(person.lastname, "Boss")
+
+    def test_update_rejects_none_for_non_nullable_field_with_model_default(
+        self,
+    ) -> None:
+        message = SystemMessageFactory(order=5)
+        serializer = DefaultedModelFieldMappingSerializer(
+            message, data={"external_order": None}
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors["order"][0].code, "null")
+
+        message.refresh_from_db()
+        self.assertEqual(message.order, 5)
+
+    def test_update_preserves_omitted_field_with_model_default(self) -> None:
+        message = SystemMessageFactory(order=5)
+        serializer = DefaultedModelFieldMappingSerializer(message, data={})
+
+        self.assertTrue(serializer.is_valid(raise_exception=True))
+        serializer.save()
+
+        message.refresh_from_db()
+        self.assertEqual(message.order, 5)
+
+    def test_multiple_nested_relations_keep_their_own_models(self) -> None:
+        serializer = MultipleNestedRelationsMappingSerializer(
+            data={
+                "external_firstname": "Hugo",
+                "external_municipality": "Muri",
+                "external_person_type": "Employee",
+            }
+        )
+
+        self.assertEqual(
+            serializer.fields["place_of_residence"].model, models.Municipality
+        )
+        self.assertEqual(serializer.fields["person_type"].model, models.PersonType)
+        self.assertTrue(serializer.is_valid(raise_exception=True))
+
+        person = serializer.save()
+
+        self.assertEqual(person.place_of_residence.title, "Muri")
+        self.assertIsInstance(person.place_of_residence, models.Municipality)
+        self.assertEqual(person.person_type.title, "Employee")
+        self.assertIsInstance(person.person_type, models.PersonType)
+
+    def test_many_preserves_nested_relations_for_each_item(self) -> None:
+        serializer = MultipleNestedRelationsMappingSerializer(
+            data=[
+                {
+                    "external_firstname": "Hugo",
+                    "external_municipality": "Muri",
+                    "external_person_type": "Employee",
+                },
+                {
+                    "external_firstname": "Stefanie",
+                    "external_municipality": "Bern",
+                    "external_person_type": "Volunteer",
+                },
+            ],
+            many=True,
+        )
+
+        self.assertTrue(serializer.is_valid(raise_exception=True))
+        people = serializer.save()
+
+        self.assertEqual(
+            [
+                (
+                    person.firstname,
+                    person.place_of_residence.title,
+                    person.person_type.title,
+                )
+                for person in people
+            ],
+            [("Hugo", "Muri", "Employee"), ("Stefanie", "Bern", "Volunteer")],
+        )
+
+    def test_many_allows_nested_relations_to_be_omitted_per_item(self) -> None:
+        serializer = MultipleNestedRelationsMappingSerializer(
+            data=[
+                {
+                    "external_firstname": "Hugo",
+                    "external_municipality": "Muri",
+                    "external_person_type": "Employee",
+                },
+                {"external_firstname": "Stefanie"},
+            ],
+            many=True,
+        )
+
+        self.assertTrue(serializer.is_valid(raise_exception=True))
+        people = serializer.save()
+
+        self.assertEqual(people[0].place_of_residence.title, "Muri")
+        self.assertEqual(people[0].person_type.title, "Employee")
+        self.assertIsNone(people[1].place_of_residence)
+        self.assertIsNone(people[1].person_type)
+
+    def test_many_rejects_explicit_none_for_nested_non_nullable_field(self) -> None:
+        serializer = MultipleNestedRelationsMappingSerializer(
+            data=[
+                {
+                    "external_firstname": "Hugo",
+                    "external_municipality": None,
+                    "external_person_type": "Employee",
+                }
+            ],
+            many=True,
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors[0]["place_of_residence"]["title"][0].code,
+            "null",
         )
 
     def test_list_mapping_serializer_map_initial_data(self) -> None:

--- a/app/tests/test_mapping_serializer_data.py
+++ b/app/tests/test_mapping_serializer_data.py
@@ -28,6 +28,49 @@ class TestMappingSerializer(MappingSerializer):
         }
 
 
+class NullableFieldMappingSerializer(MappingSerializer):
+    class Meta:
+        model = models.Person
+        fields = "__all__"
+
+    @property  # type: ignore[misc]
+    def mapping(self) -> dict[str, dict[str, Any]]:
+        return {"person": {"external_nullable": "lastname"}}
+
+
+class NonNullableFieldMappingSerializer(MappingSerializer):
+    class Meta:
+        model = models.Person
+        fields = "__all__"
+
+    @property  # type: ignore[misc]
+    def mapping(self) -> dict[str, dict[str, Any]]:
+        return {"person": {"external_non_nullable": "firstname"}}
+
+
+class NestedFieldMappingSerializer(MappingSerializer):
+    class Meta:
+        model = models.Person
+        fields = "__all__"
+
+    @property  # type: ignore[misc]
+    def mapping(self) -> dict[str, dict[str, Any]]:
+        return {"person": {"external.nested_nullable": "lastname"}}
+
+
+class DefaultFieldMappingSerializer(NullableFieldMappingSerializer):
+    def default_lastname(self) -> str:
+        self.default_calls = getattr(self, "default_calls", 0) + 1
+        return "Default lastname"
+
+
+class FormattingFieldMappingSerializer(NullableFieldMappingSerializer):
+    def format_lastname(self, value: Any) -> Any:
+        self.formatted_values = getattr(self, "formatted_values", [])
+        self.formatted_values.append(value)
+        return value
+
+
 class MappingSerializerTestCase(APITestCase):
     def test_mapping_serializer_map_initial_data(self) -> None:
         data = {
@@ -70,6 +113,72 @@ class MappingSerializerTestCase(APITestCase):
 
         mapped_data = TestMappingSerializer().map_data(data)
         self.assertEqual(mapped_data, expected_data)
+
+    def test_missing_nullable_field_is_omitted_from_mapped_data(self) -> None:
+        serializer = NullableFieldMappingSerializer(data={})
+
+        self.assertEqual(serializer.initial_data, {})
+
+    def test_explicit_none_remains_in_mapped_data(self) -> None:
+        serializer = NullableFieldMappingSerializer(data={"external_nullable": None})
+
+        self.assertEqual(serializer.initial_data, {"lastname": None})
+
+    def test_allow_null_accepts_explicit_none(self) -> None:
+        serializer = NullableFieldMappingSerializer(data={"external_nullable": None})
+
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data, {"lastname": None})
+
+    def test_disallow_null_rejects_explicit_none(self) -> None:
+        serializer = NonNullableFieldMappingSerializer(
+            data={"external_non_nullable": None}
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors["firstname"][0].code, "null")
+
+    def test_missing_field_invokes_default_method(self) -> None:
+        serializer = DefaultFieldMappingSerializer(data={})
+
+        self.assertEqual(serializer.initial_data, {"lastname": "Default lastname"})
+        self.assertEqual(serializer.default_calls, 1)
+
+    def test_formatter_receives_explicit_none(self) -> None:
+        serializer = FormattingFieldMappingSerializer(data={"external_nullable": None})
+
+        self.assertEqual(serializer.initial_data, {"lastname": None})
+        self.assertEqual(serializer.formatted_values, [None])
+
+    def test_formatter_is_not_called_for_missing_field(self) -> None:
+        serializer = FormattingFieldMappingSerializer(data={})
+
+        self.assertEqual(serializer.initial_data, {})
+        self.assertFalse(hasattr(serializer, "formatted_values"))
+
+    def test_nested_mapping_distinguishes_missing_and_explicit_none(self) -> None:
+        serializer = NestedFieldMappingSerializer()
+
+        self.assertEqual(serializer.map_data({}), {})
+        self.assertEqual(serializer.map_data({"external": {}}), {})
+        self.assertEqual(
+            serializer.map_data({"external": {"nested_nullable": None}}),
+            {"lastname": None},
+        )
+
+    def test_list_mapping_distinguishes_missing_and_explicit_none(self) -> None:
+        serializer = NestedFieldMappingSerializer(many=True)
+
+        self.assertEqual(
+            serializer.map_list_data(
+                [
+                    {},
+                    {"external": {}},
+                    {"external": {"nested_nullable": None}},
+                ]
+            ),
+            [{}, {}, {"lastname": None}],
+        )
 
     def test_list_mapping_serializer_map_initial_data(self) -> None:
         data = [

--- a/changes/data-mapping-null-presence.bugfix
+++ b/changes/data-mapping-null-presence.bugfix
@@ -1,0 +1,5 @@
+Distinguish omitted mapping inputs from explicit ``None`` values. Explicit nulls are
+now passed to serializer fields so that ``allow_null`` controls validation. Formatters
+are no longer called for omitted inputs unless a corresponding ``default_<field>()``
+method supplies a value; consumers that used formatters to default missing inputs
+should move that behavior into the supported default method.

--- a/changes/data-mapping-null-presence.bugfix
+++ b/changes/data-mapping-null-presence.bugfix
@@ -2,4 +2,6 @@ Distinguish omitted mapping inputs from explicit ``None`` values. Explicit nulls
 now passed to serializer fields so that ``allow_null`` controls validation. Formatters
 are no longer called for omitted inputs unless a corresponding ``default_<field>()``
 method supplies a value; consumers that used formatters to default missing inputs
-should move that behavior into the supported default method.
+should move that behavior into the supported default method. List mappings now apply
+these default and formatter hooks consistently to each item, including nested relation
+mappings.

--- a/django_features/serializers.py
+++ b/django_features/serializers.py
@@ -221,6 +221,7 @@ class NestedMappingSerializer(BaseMappingSerializer):
 class DataMappingSerializerMixin(PropertySerializerMixin):
     _default_prefix = "default"
     _format_prefix = "format"
+    unmapped_data: Any
 
     def _get_nested_data(self, field_path: list[str], data: Any) -> tuple[Any, bool]:
         field_name = field_path[0]
@@ -248,26 +249,33 @@ class DataMappingSerializerMixin(PropertySerializerMixin):
         if not isinstance(initial_data, dict):
             return initial_data
 
-        data: dict[str, Any] = {}
-        for external_name, internal_name in self.model_mapping.items():
-            external_field_path = external_name.split(self.relation_separator)
-            value, found = self._get_nested_data(external_field_path, initial_data)
-            if not found:
-                default_func = getattr(
-                    self, f"{self._default_prefix}_{internal_name}", None
+        previous_unmapped_data = getattr(self, "unmapped_data", empty)
+        self.unmapped_data = initial_data
+        try:
+            data: dict[str, Any] = {}
+            for external_name, internal_name in self.model_mapping.items():
+                external_field_path = external_name.split(self.relation_separator)
+                value, found = self._get_nested_data(external_field_path, initial_data)
+                if not found:
+                    default_func = getattr(
+                        self, f"{self._default_prefix}_{internal_name}", None
+                    )
+                    if default_func is not None:
+                        value = default_func()
+                    else:
+                        continue
+                format_func = getattr(
+                    self, f"{self._format_prefix}_{internal_name}", None
                 )
-                if default_func is not None:
-                    value = default_func()
-                else:
-                    continue
-            format_func = getattr(self, f"{self._format_prefix}_{internal_name}", None)
-            if format_func is not None:
-                value = format_func(value)
-            internal_field_path = internal_name.split(self.relation_separator)
-            data.update(
-                self._get_data_with_internal_key(internal_field_path, data, value)
-            )
-        return data
+                if format_func is not None:
+                    value = format_func(value)
+                internal_field_path = internal_name.split(self.relation_separator)
+                data.update(
+                    self._get_data_with_internal_key(internal_field_path, data, value)
+                )
+            return data
+        finally:
+            self.unmapped_data = previous_unmapped_data
 
 
 class ListDataMappingSerializer(serializers.ListSerializer, DataMappingSerializerMixin):

--- a/django_features/serializers.py
+++ b/django_features/serializers.py
@@ -131,10 +131,13 @@ class BaseMappingSerializer(CustomFieldBaseModelSerializer, PropertySerializerMi
                         ),
                         required=False,
                     )
+        initial_data = getattr(self, "initial_data", {})
+        if not isinstance(initial_data, dict):
+            initial_data = {}
         for field_name, field in nested_fields.items():
-            nested_data = self.initial_data.get(field_name)
+            nested_data = initial_data.get(field_name, empty)
             if not isinstance(nested_data, dict):
-                continue
+                nested_data = empty
             self.related_fields.add(field_name)
             fields[field_name] = NestedMappingSerializer(
                 data=nested_data,
@@ -154,11 +157,12 @@ class BaseMappingSerializer(CustomFieldBaseModelSerializer, PropertySerializerMi
     def create(self, validated_data: dict[str, Any]) -> models.Model:
         relations_to_save: dict[str, Any] = {}
         for field in self.related_fields:
-            value = validated_data.pop(field, None)
+            if field not in validated_data:
+                continue
+            value = validated_data.pop(field)
             serializer = self.fields.get(field)
             if isinstance(serializer, NestedMappingSerializer):
-                serializer.is_valid(raise_exception=True)
-                relations_to_save[field] = serializer.save()
+                relations_to_save[field] = serializer.create(value)
             elif value is not None:
                 relations_to_save[field] = value
         instance = super().create(validated_data)
@@ -175,11 +179,12 @@ class BaseMappingSerializer(CustomFieldBaseModelSerializer, PropertySerializerMi
         self, instance: models.Model, validated_data: dict[str, Any]
     ) -> models.Model:
         for field in self.related_fields:
-            value = validated_data.pop(field, None)
+            if field not in validated_data:
+                continue
+            value = validated_data.pop(field)
             serializer = self.fields.get(field)
             if isinstance(serializer, NestedMappingSerializer):
-                serializer.is_valid(raise_exception=True)
-                value = serializer.save()
+                value = serializer.create(value)
             model_field = self.model._meta.get_field(field)
             if model_field.many_to_many or model_field.one_to_many:
                 getattr(instance, field).set(value)
@@ -205,7 +210,11 @@ class NestedMappingSerializer(BaseMappingSerializer):
         self.exclude = exclude
         self.mapping_fields = nested_fields
         self.mapping = parent_mapping
-        self.Meta.model = field.related_model
+
+        class Meta(self.Meta):  # type: ignore[name-defined]
+            model = field.related_model
+
+        setattr(self, "Meta", Meta)
         super().__init__(*args, **kwargs)
 
 
@@ -236,6 +245,9 @@ class DataMappingSerializerMixin(PropertySerializerMixin):
         return {field_name: value}
 
     def map_data(self, initial_data: Any) -> Any:
+        if not isinstance(initial_data, dict):
+            return initial_data
+
         data: dict[str, Any] = {}
         for external_name, internal_name in self.model_mapping.items():
             external_field_path = external_name.split(self.relation_separator)
@@ -264,14 +276,17 @@ class ListDataMappingSerializer(serializers.ListSerializer, DataMappingSerialize
         self.mapping = kwargs.pop("mapping", {})
         self.model = kwargs.pop("model")
         self.unmapped_data = data if data is not empty else []
-        mapped_data = self.map_list_data(self.unmapped_data)
-        super().__init__(data=mapped_data, *args, **kwargs)
+        super().__init__(data=data, *args, **kwargs)
+        if data is not empty:
+            self.initial_data = self.map_list_data(data)
 
-    def map_list_data(self, initial_data: Any) -> list[Any]:
-        list_data: list[dict[str, Any]] = []
-        for item in initial_data:
-            list_data.append(self.map_data(item))
-        return list_data
+    def map_data(self, initial_data: Any) -> Any:
+        return self.child.map_data(initial_data)
+
+    def map_list_data(self, initial_data: Any) -> Any:
+        if not isinstance(initial_data, list):
+            return initial_data
+        return [self.map_data(item) for item in initial_data]
 
 
 class MappingSerializer(BaseMappingSerializer, DataMappingSerializerMixin):

--- a/django_features/serializers.py
+++ b/django_features/serializers.py
@@ -4,7 +4,6 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import FieldDoesNotExist
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import NOT_PROVIDED
 from rest_framework import serializers
 from rest_framework.fields import empty
 from rest_framework.relations import ManyRelatedField
@@ -216,9 +215,9 @@ class DataMappingSerializerMixin(PropertySerializerMixin):
 
     def _get_nested_data(self, field_path: list[str], data: Any) -> tuple[Any, bool]:
         field_name = field_path[0]
-        if not isinstance(data, dict):
+        if not isinstance(data, dict) or field_name not in data:
             return None, False
-        value = data.get(field_name, None)
+        value = data[field_name]
         if len(field_path) > 1:
             return self._get_nested_data(field_path[1:], value)
         return value, True
@@ -253,16 +252,6 @@ class DataMappingSerializerMixin(PropertySerializerMixin):
             if format_func is not None:
                 value = format_func(value)
             internal_field_path = internal_name.split(self.relation_separator)
-            if value is None:
-                if getattr(self, "instance") is None:
-                    continue
-                else:
-                    try:
-                        field = self.model._meta.get_field(internal_field_path[0])
-                        if not field.null and field.default != NOT_PROVIDED:
-                            continue
-                    except FieldDoesNotExist:
-                        pass
             data.update(
                 self._get_data_with_internal_key(internal_field_path, data, value)
             )


### PR DESCRIPTION
## Description

Explicit nulls are now passed to serializer fields so that ``allow_null`` controls validation. Formatters are no longer called for omitted inputs unless a corresponding ``default_<field>()`` method supplies a value; consumers that used formatters to default missing inputs should move that behavior into the supported default method.


Belongs to PBI [TI-3962].

## Checklist

The following checklist should help us to stick to our "definition of done":

- [x] Proposed changes include tests.
- [x] Good error handling with useful messages
- [x] Changelog added
~~- [ ] Django migration files have a meaningful name (not 0000_auto_xyz.py nor 0000_alter_xy_model).~~
~~- [ ] Strings are set and translation catalogs have been updated (i18n-scan or i18n-update) and translations made.~~
~~- [ ] Readme has been updated if changes interfere with the setup process.~~


[TI-3962]: https://4teamwork.atlassian.net/browse/TI-3962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ