### PR TITLE
CI: Migrate runner from self-hosted to lotus-arc

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: lotus-arc
     services:
       postgres:
         image: postgres


### PR DESCRIPTION
## Description
Migration der CI auf das neue Actions-Runner-Scale-Set.
runs-on: self-hosted -> lotus-arc. docker, docker build und docker compose laufen unverändert.



Belongs to PBI [OPS-140].



[OPS-140]: https://4teamwork.atlassian.net/browse/OPS-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ